### PR TITLE
Change source filename

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,7 +27,7 @@ makedepends=('bazel' 'python-numpy' 'rocm' 'rocm-libs' 'miopen' 'rccl' 'git'
              'python-keras-applications' 'python-keras-preprocessing'
              'cython')
 optdepends=('tensorboard: Tensorflow visualization toolkit')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/tensorflow/tensorflow/archive/v${_pkgver}.tar.gz"
+source=("$pkgbase-$pkgver.tar.gz::https://github.com/tensorflow/tensorflow/archive/v${_pkgver}.tar.gz"
         fix-h5py3.0.patch
         build-against-actual-mkl.patch)
 


### PR DESCRIPTION
Use the pkgbase instead of the pkgname when downloading the source to avoid possible variability (and therefore redownloads) when enabling/disabling the various packages.

I realize this is a very minor PR, so feel free to ignore if you don't want to include it.
