### PR TITLE
ROCm 5.0.2 compatibility

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,7 +24,7 @@ depends=('c-ares' 'intel-mkl' 'onednn' 'pybind11' 'openssl' 'lmdb' 'libpng' 'cur
 makedepends=('bazel' 'python-numpy' 'rocm-hip-sdk' 'miopen' 'rccl' 'git'
              'python-pip' 'python-wheel' 'python-setuptools' 'python-h5py'
              'python-keras-applications' 'python-keras-preprocessing'
-             'cython' 'roctracer' 'hipsolver' 'rocm-hip-sdk')
+             'cython' 'roctracer' 'hipsolver')
 optdepends=('tensorboard: Tensorflow visualization toolkit')
 source=("$pkgname::git+https://github.com/ROCmSoftwarePlatform/tensorflow-upstream.git"
         fix-c++17-compat.patch

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,8 +24,7 @@ depends=('c-ares' 'intel-mkl' 'onednn' 'pybind11' 'openssl' 'lmdb' 'libpng' 'cur
 makedepends=('bazel' 'python-numpy' 'rocm-hip-sdk' 'miopen' 'rccl' 'git'
              'python-pip' 'python-wheel' 'python-setuptools' 'python-h5py'
              'python-keras-applications' 'python-keras-preprocessing'
-             'cython' 'rocblas' 'rocrand' 'rocfft' 'hipfft' 'roctracer'
-             'hipsparse' 'hipsolver' 'rocsolver' 'rocm-hip-sdk')
+             'cython' 'roctracer' 'hipsolver' 'rocm-hip-sdk')
 optdepends=('tensorboard: Tensorflow visualization toolkit')
 source=("$pkgname::git+https://github.com/ROCmSoftwarePlatform/tensorflow-upstream.git"
         fix-c++17-compat.patch

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -21,10 +21,10 @@ url="https://www.tensorflow.org/"
 license=('APACHE')
 arch=('x86_64')
 depends=('c-ares' 'intel-mkl' 'onednn' 'pybind11' 'openssl' 'lmdb' 'libpng' 'curl' 'giflib' 'icu' 'libjpeg-turbo')
-makedepends=('bazel' 'python-numpy' 'rocm-hip-sdk' 'miopen' 'rccl' 'git'
+makedepends=('bazel' 'python-numpy' 'rocm-hip-sdk' 'miopen' 'rccl' 'roctracer' 'hipsolver' 'git'
              'python-pip' 'python-wheel' 'python-setuptools' 'python-h5py'
              'python-keras-applications' 'python-keras-preprocessing'
-             'cython' 'roctracer' 'hipsolver')
+             'cython')
 optdepends=('tensorboard: Tensorflow visualization toolkit')
 source=("$pkgname::git+https://github.com/ROCmSoftwarePlatform/tensorflow-upstream.git"
         fix-c++17-compat.patch

--- a/hiprand.patch
+++ b/hiprand.patch
@@ -1,0 +1,11 @@
+--- tensorflow-rocm/third_party/gpus/rocm_configure.bzl	2022-03-11 20:46:02.867224360 +0100
++++ tensorflow-rocm/third_party/gpus/rocm_configure.bzl	2022-03-11 20:47:46.923766740 +0100
+@@ -331,7 +331,7 @@
+             ("amdhip64", rocm_config.rocm_toolkit_path + "/hip"),
+             ("rocblas", rocm_config.rocm_toolkit_path + "/rocblas"),
+             (hipfft_or_rocfft, rocm_config.rocm_toolkit_path + "/" + hipfft_or_rocfft),
+-            ("hiprand", rocm_config.rocm_toolkit_path),
++            ("hiprand", rocm_config.rocm_toolkit_path + "/hiprand"),
+             ("MIOpen", rocm_config.rocm_toolkit_path + "/miopen"),
+             ("rccl", rocm_config.rocm_toolkit_path + "/rccl"),
+             ("hipsparse", rocm_config.rocm_toolkit_path + "/hipsparse"),


### PR DESCRIPTION
Tensorflow version 2.8.0 doesn't seem to be compatible with ROCm 5.0.2. So this PKGBUILD uses the ROCmSoftwarePlatform / tensorflow-upstream git as source.  The package depends on miopen 5.0.2 which is currently not up to date, but a pull request for 5.0.2 is pending.

Closes #36