### PR TITLE
Don't force users to build rocm binaries

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,7 +22,7 @@ url="https://www.tensorflow.org/"
 license=('APACHE')
 arch=('x86_64')
 depends=('c-ares' 'pybind11' 'openssl' 'lmdb' 'libpng' 'curl' 'giflib' 'icu' 'libjpeg-turbo' 'openmp')
-makedepends=('bazel' 'python-numpy' 'opencl-amd-dev' 'python-pip' 'python-wheel'
+makedepends=('bazel' 'python-numpy' 'opencl-amd-dev' 'git' 'python-pip' 'python-wheel'
              'python-setuptools' 'python-h5py' 'python-keras-applications' 'python-keras-preprocessing'
              'cython' 'patchelf' 'python-requests')
 optdepends=('tensorboard: Tensorflow visualization toolkit')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,7 +22,7 @@ url="https://www.tensorflow.org/"
 license=('APACHE')
 arch=('x86_64')
 depends=('c-ares' 'pybind11' 'openssl' 'lmdb' 'libpng' 'curl' 'giflib' 'icu' 'libjpeg-turbo' 'openmp')
-makedepends=('bazel' 'python-numpy' 'rocm-hip-sdk' 'rccl' 'git' 'miopen' 'python-pip' 'python-wheel'
+makedepends=('bazel' 'python-numpy' 'opencl-amd-dev' 'python-pip' 'python-wheel'
              'python-setuptools' 'python-h5py' 'python-keras-applications' 'python-keras-preprocessing'
              'cython' 'patchelf' 'python-requests')
 optdepends=('tensorboard: Tensorflow visualization toolkit')


### PR DESCRIPTION
the package opencl-amd-dev already contain all the binaries of rocm for arch. Use it instead of forcing users to build rocm from source.