### PR TITLE
sed for find_namespace_packages for setup.py

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -81,6 +81,9 @@ prepare() {
   # thinks about which versions should be used anyway. ;) (FS#68772)
   sed -i -E "s/'([0-9a-z_-]+) .= [0-9].+[0-9]'/'\1'/" tensorflow-${_pkgver}/tensorflow/tools/pip_package/setup.py
 
+  # setup.py generates ~1Mb of warnings if you don't explicitly include namespace packages.
+  sed -i -E "s/find_packages/find_namespace_packages/" tensorflow-upstream/tensorflow/tools/pip_package/setup.py
+
   patch -Np1 -i "${srcdir}/tensorflow-2.10-sparse-transpose-op2.patch" -d tensorflow-${_pkgver}
 
   cp -r tensorflow-${_pkgver} tensorflow-${_pkgver}-rocm


### PR DESCRIPTION
This commit resolves ~1 megabyte of warnings generated by setuptools. It specifically addresses issue #51. [Per StackOverflow,](https://stackoverflow.com/questions/72363601) `find_namespace_packages` is an appropriate substitution for `find_packages` in this case.