### PR TITLE
Use gcc-12 instead of symlink from cuda package.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -127,7 +127,7 @@ prepare() {
   # Does tensorflow really need the compiler overridden in 5 places? Yes.
   export CC=gcc
   export CXX=g++
-  export GCC_HOST_COMPILER_PATH=/opt/cuda/bin/gcc
+  export GCC_HOST_COMPILER_PATH=/usr/bin/gcc-12
   export HOST_C_COMPILER=/usr/bin/${CC}
   export HOST_CXX_COMPILER=/usr/bin/${CXX}
   export TF_CUDA_CLANG=0  # Clang currently disabled because it's not compatible at the moment.


### PR DESCRIPTION
The `/opt/cuda/bin/gcc` symlink does only exist in the `cuda` package and points to `gcc-12`. Since `cuda` is not a dependency of this package, but `gcc12` is, this should be set directly.

Patches #56 